### PR TITLE
fix misapplied discussion questions in m1w1d3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Week 1, Day 2 Morning Discussion Questions
+# Week 1, Day 3 Morning Discussion Questions
 
 ## Instructions
 
@@ -6,110 +6,93 @@ Take 30 minutes and answer the following questions together with your group. Tak
 
 ## Questions
 
-1 . What does the below method return?
+1 . If the `Animal` class is defined like this:
 
 ```ruby
-def greet(name)
-  puts "Hello, #{name}"
+class Animal
+
+  def species
+    "cat"
+  end
+
 end
-greet("Steven") #=> ?
 ```
 
-2 . What does this method return?
+How would you 
+
+a. Make a new instance of `Animal`?
+b. `puts` out to the terminal, the species of that new `Animal` instance?
+
+2 . Although we all know that cats are the best species, not all animals are cats (unfortunately). How could you change the `Animal` class so that an instance of `animal` can have its species set to any species at all?
+
+3 . We have the following class, and the following two instances of that class:
 
 ```ruby
-def hate_steven?(name)
-  if name == "Steven"
-    "OMG He's the worst"
-  else
-    "You cool"
+class Animal
+
+  def species
+    "cat"
+  end
+end
+
+maru = Animal.new
+hanna = Animal.new
+```
+
+Given the above, what will the following return? Why?
+
+```ruby
+maru == hanna
+```
+
+4 . Given the following class:
+
+```ruby
+class Animal
+  
+  def species 
+    my_species = "cat"
+  end
+
+  def say_species
+    puts "Hi! I'm a #{my_species}"
   end
 end
 ```
 
-3 . How would you select all of the words that start with the letter "a" from the below array?
+What will happen when we invoke the following code?
 
 ```ruby
-["apple", "pear", "face", "champagne", "palm tree", "aardvark", "pineapple"]
+maru = Animal.new
+maru.say_species
 ```
 
-4 . Write a method that takes in an argument of a sentence and returns the
-number of words in the sentence
+Is it broken? Why? How can you fix it?
+
+5 . Reverse engineer this code (i.e., write the class that will make the code work as invoked below):
 
 ```ruby
-word_count("Hi, isn't this a great and interesting sentence??")
- # => 8
+frederick = Animal.new("bull")
+frederick.species
+# => "bull"
 ```
 
-5 . What will the following method return?
+**Hint:** How can you instantiate, or *initialize*, an instance of a class with a given value? What kind of variable would you use so that that value can be shared across instance methods within a class?
+
+6 . Given the following code:
 
 ```ruby
-def rude_greeting(name=nil)
- name ||= "you jerk"
- puts "Hey there, #{name}"
-end
-```
-
-6 . What will the following `puts`?
-
-<p align="center">
-  <img src="https://curriculum-content.s3.amazonaws.com/module-1/discussion-questions/object-orientation-in-ruby/Image_109_%20Cat_Image.png" width="300" alt="happy cat"/>
-</p>
-
-```ruby
-best_animal = "cat"
-favorite_animal = best_animal
-puts favorite_animal
-# => ?
-```
-
-7 . What will the following `puts`?
-
-```ruby
-def my_favorite_animal
-  "cat"
-end
-
-best_animal = my_favorite_animal
-
-puts best_animal
-```
-
-8 . What error, if any, will the following code raise?
-
-```ruby
-"Blink" + 182
-```
-
-9 . How would you `puts` out any and all foods that are delicious?
-
-```ruby
-foods = {"pie" => "delicious", "broccoli" => "not delicious",
-"carrots" => "not delicious", "apples" => "delicious",
-"peanut butter" => "delicious"}
-```
-
-10 . Delete all elements of the `foods` hash that are *not* delicious.
-
-11 . What is the return value of this method?
-```ruby
-  character_names = ["Daenerys Targaryen", "Jon Snow" ,"Arya Stark", "Tyrion Lannister", "Sansa Stark", "Cersei Lannister", "Margaery Tyrell"]
-
-  def downcase_all(array_of_strings)
-    array_of_strings.each do |one_string|
-      one_string.downcase
-    end
+class Animal
+  
+  def initialize(species)
+    @species = species
   end
+
+end
+
+lil_bub = Animal.new("cat")
 ```
 
-12 . Write a method that `puts` out a random Archer quote.
-```ruby
-  archer = {
-      "name" => "Sterling Mallory Archer",
-      "co-workers"=> ["Lana Kane", "Cyril Figgis", "Cheryl Tunt", "Pam Poovey", "Dr Krieger"],
-      "favorite_drink" => "Bloody Mary",
-      "Quotes" => ["I swear to god, I had something for this", "Phrasing", "Boop", "Danger Zone", "Read a book", "Do you not?", "Can't or won't?"]
-  }
-```
+What is the relationship between `lil_bub` and the `Animal` class? 
 
 <p class='util--hide'>View <a href='https://learn.co/lessons/immersive-week-1-discussion-questions'>Immersive Week 1 Discussion Questions</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
Chicago web 111819 noticed this morning that they were looking at the same discussion questions.

This pull request brings in the W1D3 question text from Mod 1 version 2.1, so the day's questions are about object orientation as intended.